### PR TITLE
Add database-specific span bulk insert providers

### DIFF
--- a/src/Asynkron.OtelReceiver/Asynkron.OtelReceiver.csproj
+++ b/src/Asynkron.OtelReceiver/Asynkron.OtelReceiver.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.61.0" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.61.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
   </ItemGroup>
 

--- a/src/Asynkron.OtelReceiver/Data/Providers/ISpanBulkInserter.cs
+++ b/src/Asynkron.OtelReceiver/Data/Providers/ISpanBulkInserter.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Asynkron.OtelReceiver.Data.Providers;
+
+/// <summary>
+/// Abstraction responsible for inserting a batch of spans into the underlying database.
+/// Each database provider can choose the optimal strategy (binary import, batched EF operations, etc.).
+/// </summary>
+public interface ISpanBulkInserter
+{
+    Task InsertAsync(OtelReceiverContext context, IReadOnlyCollection<SpanEntity> spans, CancellationToken cancellationToken = default);
+}

--- a/src/Asynkron.OtelReceiver/Data/Providers/PostgresSpanBulkInserter.cs
+++ b/src/Asynkron.OtelReceiver/Data/Providers/PostgresSpanBulkInserter.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Asynkron.OtelReceiver.Data.Providers;
+
+/// <summary>
+/// Uses PostgreSQL's binary <c>COPY</c> support to quickly persist spans.
+/// </summary>
+public class PostgresSpanBulkInserter(ILogger<PostgresSpanBulkInserter> logger) : ISpanBulkInserter
+{
+    private readonly ILogger<PostgresSpanBulkInserter> _logger = logger;
+
+    public async Task InsertAsync(OtelReceiverContext context, IReadOnlyCollection<SpanEntity> spans, CancellationToken cancellationToken = default)
+    {
+        if (spans.Count == 0)
+        {
+            return;
+        }
+
+        var connection = (NpgsqlConnection)context.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+        await using var writer = await connection.BeginBinaryImportAsync(
+            """
+            COPY "Spans" (
+                    "SpanId",
+                    "StartTimestamp",
+                    "EndTimestamp",
+                    "TraceId",
+                    "ParentSpanId",
+                    "ServiceName",
+                    "OperationName",
+                    "AttributeMap",
+                    "Events",
+                    "Proto") FROM STDIN (FORMAT BINARY)
+            """);
+
+        try
+        {
+            foreach (var span in spans)
+            {
+                await writer.StartRowAsync(cancellationToken);
+                await writer.WriteAsync(span.SpanId, NpgsqlDbType.Text, cancellationToken);
+                await writer.WriteAsync(span.StartTimestamp, NpgsqlDbType.Bigint, cancellationToken);
+                await writer.WriteAsync(span.EndTimestamp, NpgsqlDbType.Bigint, cancellationToken);
+                await writer.WriteAsync(span.TraceId, NpgsqlDbType.Text, cancellationToken);
+                await writer.WriteAsync(span.ParentSpanId, NpgsqlDbType.Text, cancellationToken);
+                await writer.WriteAsync(span.ServiceName, NpgsqlDbType.Text, cancellationToken);
+                await writer.WriteAsync(span.OperationName, NpgsqlDbType.Text, cancellationToken);
+                await writer.WriteAsync(span.AttributeMap, NpgsqlDbType.Array | NpgsqlDbType.Text, cancellationToken);
+                await writer.WriteAsync(span.Events, NpgsqlDbType.Array | NpgsqlDbType.Text, cancellationToken);
+                await writer.WriteAsync(span.Proto, NpgsqlDbType.Bytea, cancellationToken);
+            }
+
+            await writer.CompleteAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to bulk insert spans using PostgreSQL COPY");
+            await writer.CancelAsync(cancellationToken);
+            throw;
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+}

--- a/src/Asynkron.OtelReceiver/Data/Providers/SqliteSpanBulkInserter.cs
+++ b/src/Asynkron.OtelReceiver/Data/Providers/SqliteSpanBulkInserter.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Asynkron.OtelReceiver.Data.Providers;
+
+/// <summary>
+/// Uses EF Core's batched change tracker which maps well to SQLite and keeps conversions consistent.
+/// </summary>
+public class SqliteSpanBulkInserter : ISpanBulkInserter
+{
+    public async Task InsertAsync(OtelReceiverContext context, IReadOnlyCollection<SpanEntity> spans, CancellationToken cancellationToken = default)
+    {
+        if (spans.Count == 0)
+        {
+            return;
+        }
+
+        // SQLite does not expose a COPY equivalent, but EF Core can still send the inserts as a single transaction.
+        await context.Spans.AddRangeAsync(spans, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an ISpanBulkInserter abstraction so database providers can own their span batching strategy
- implement PostgreSQL binary COPY and EF Core-backed SQLite inserters and register them via Program.cs
- add the EF Core SQLite package so the provider can be configured at runtime

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da3392e8cc8328a1c6326b6e5a6ef4