### PR TITLE
Add live metrics monitoring CLI and sqlite coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore Asynkron.OtelReceiver.sln
+
+      - name: Build
+        run: dotnet build Asynkron.OtelReceiver.sln --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test Asynkron.OtelReceiver.sln --no-build --configuration Release

--- a/Asynkron.OtelReceiver.sln
+++ b/Asynkron.OtelReceiver.sln
@@ -4,6 +4,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Asynkron.OtelReceiver.Core"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Asynkron.OtelReceiver", "src\Asynkron.OtelReceiver\Asynkron.OtelReceiver.csproj", "{C450C714-E004-4D85-A3E6-3788D7AC4C29}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Asynkron.OtelReceiver.Host", "src\Asynkron.OtelReceiver.Host\Asynkron.OtelReceiver.Host.csproj", "{1CCF286C-F6FC-4A5A-8C86-5690534FC47E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Asynkron.OtelReceiver.Tests", "tests\Asynkron.OtelReceiver.Tests\Asynkron.OtelReceiver.Tests.csproj", "{4345F940-93A6-4647-9F64-A8D03C5FA5A8}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -18,5 +22,13 @@ Global
         {C450C714-E004-4D85-A3E6-3788D7AC4C29}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {C450C714-E004-4D85-A3E6-3788D7AC4C29}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {C450C714-E004-4D85-A3E6-3788D7AC4C29}.Release|Any CPU.Build.0 = Release|Any CPU
+        {1CCF286C-F6FC-4A5A-8C86-5690534FC47E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {1CCF286C-F6FC-4A5A-8C86-5690534FC47E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {1CCF286C-F6FC-4A5A-8C86-5690534FC47E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {1CCF286C-F6FC-4A5A-8C86-5690534FC47E}.Release|Any CPU.Build.0 = Release|Any CPU
+        {4345F940-93A6-4647-9F64-A8D03C5FA5A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4345F940-93A6-4647-9F64-A8D03C5FA5A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {4345F940-93A6-4647-9F64-A8D03C5FA5A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {4345F940-93A6-4647-9F64-A8D03C5FA5A8}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
 EndGlobal

--- a/src/Asynkron.OtelReceiver.Core/Asynkron.OtelReceiver.Core.csproj
+++ b/src/Asynkron.OtelReceiver.Core/Asynkron.OtelReceiver.Core.csproj
@@ -38,6 +38,10 @@
 
             <Generator>MSBuild:Compile</Generator>
         </Protobuf>
+        <Protobuf Include="receiver_metrics.proto">
+            <Generator>MSBuild:Compile</Generator>
+            <GrpcServices>Both</GrpcServices>
+        </Protobuf>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Asynkron.OtelReceiver.Core/receiver_metrics.proto
+++ b/src/Asynkron.OtelReceiver.Core/receiver_metrics.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package asynkron.otelreceiver.monitoring.v1;
+
+option csharp_namespace = "Asynkron.OtelReceiver.Monitoring.V1";
+
+import "google/protobuf/empty.proto";
+
+message ReceiverMetricsUpdate {
+  int64 spans_received = 1;
+  int64 spans_stored = 2;
+  int64 logs_received = 3;
+  int64 logs_stored = 4;
+  int64 metrics_received = 5;
+  int64 metrics_stored = 6;
+}
+
+service ReceiverMetricsService {
+  rpc SubscribeMetrics(google.protobuf.Empty) returns (stream ReceiverMetricsUpdate);
+}

--- a/src/Asynkron.OtelReceiver.Host/Asynkron.OtelReceiver.Host.csproj
+++ b/src/Asynkron.OtelReceiver.Host/Asynkron.OtelReceiver.Host.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.Net.Client" Version="2.61.0" />
+    <PackageReference Include="Spectre.Console" Version="0.47.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Asynkron.OtelReceiver.Core\Asynkron.OtelReceiver.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Asynkron.OtelReceiver.Host/Program.cs
+++ b/src/Asynkron.OtelReceiver.Host/Program.cs
@@ -1,0 +1,106 @@
+using System.Runtime.CompilerServices;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Spectre.Console;
+using Asynkron.OtelReceiver.Monitoring.V1;
+using Google.Protobuf.WellKnownTypes;
+
+var address = ResolveAddress(args);
+
+if (address.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+{
+    // Allow plaintext HTTP/2 for local development scenarios.
+    AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+}
+
+using var channel = GrpcChannel.ForAddress(address);
+var client = new ReceiverMetricsService.ReceiverMetricsServiceClient(channel);
+
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    cts.Cancel();
+};
+
+var table = BuildMetricsTable(new ReceiverMetricsUpdate());
+
+await AnsiConsole.Live(table)
+    .AutoClear(false)
+    .Overflow(VerticalOverflow.Visible)
+    .Cropping(VerticalOverflowCropping.Top)
+    .StartAsync(async ctx =>
+    {
+        try
+        {
+            await foreach (var update in SubscribeAsync(client, cts.Token))
+            {
+                UpdateTable(table, update);
+                ctx.Refresh();
+            }
+        }
+        catch (RpcException rpc) when (rpc.StatusCode == StatusCode.Cancelled && cts.IsCancellationRequested)
+        {
+            // Graceful shutdown triggered by Ctrl+C.
+        }
+    });
+
+static string ResolveAddress(string[] commandLineArgs)
+{
+    var address = "http://localhost:5000";
+
+    for (var i = 0; i < commandLineArgs.Length; i++)
+    {
+        var argument = commandLineArgs[i];
+        if (argument.StartsWith("--address="))
+        {
+            address = argument[10..];
+        }
+        else if (argument == "--address" && i + 1 < commandLineArgs.Length)
+        {
+            address = commandLineArgs[i + 1];
+            i++;
+        }
+    }
+
+    if (string.IsNullOrWhiteSpace(address))
+    {
+        throw new ArgumentException("A receiver address must be provided via --address.");
+    }
+
+    return address;
+}
+
+static Table BuildMetricsTable(ReceiverMetricsUpdate snapshot)
+{
+    var table = new Table().Centered();
+    table.Title = new TableTitle("[bold yellow]OTLP Receiver Metrics[/]");
+    table.AddColumn("Metric");
+    table.AddColumn("Received");
+    table.AddColumn("Stored");
+    table.AddRow("Spans", Format(snapshot.SpansReceived), Format(snapshot.SpansStored));
+    table.AddRow("Logs", Format(snapshot.LogsReceived), Format(snapshot.LogsStored));
+    table.AddRow("Metrics", Format(snapshot.MetricsReceived), Format(snapshot.MetricsStored));
+    return table;
+}
+
+static void UpdateTable(Table table, ReceiverMetricsUpdate snapshot)
+{
+    table.Rows.Clear();
+    table.AddRow("Spans", Format(snapshot.SpansReceived), Format(snapshot.SpansStored));
+    table.AddRow("Logs", Format(snapshot.LogsReceived), Format(snapshot.LogsStored));
+    table.AddRow("Metrics", Format(snapshot.MetricsReceived), Format(snapshot.MetricsStored));
+}
+
+static string Format(long value) => $"[bold cyan]{value:N0}[/]";
+
+static async IAsyncEnumerable<ReceiverMetricsUpdate> SubscribeAsync(
+    ReceiverMetricsService.ReceiverMetricsServiceClient client,
+    [EnumeratorCancellation] CancellationToken cancellationToken)
+{
+    using var call = client.SubscribeMetrics(new Empty(), cancellationToken: cancellationToken);
+    await foreach (var update in call.ResponseStream.ReadAllAsync(cancellationToken))
+    {
+        yield return update;
+    }
+}

--- a/src/Asynkron.OtelReceiver/Monitoring/ReceiverMetricsCollector.cs
+++ b/src/Asynkron.OtelReceiver/Monitoring/ReceiverMetricsCollector.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+
+namespace Asynkron.OtelReceiver.Monitoring;
+
+/// <summary>
+/// Collects live statistics from the receiver and exposes them via <see cref="System.Diagnostics.Metrics"/> counters
+/// as well as an async stream that can be consumed by gRPC services or other observers.
+/// </summary>
+public interface IReceiverMetricsCollector
+{
+    void RecordSpansReceived(long count);
+    void RecordSpansStored(long count);
+    void RecordLogsReceived(long count);
+    void RecordLogsStored(long count);
+    void RecordMetricsReceived(long count);
+    void RecordMetricsStored(long count);
+
+    IAsyncEnumerable<ReceiverMetricsSnapshot> WatchAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Represents an immutable snapshot of the receiver's throughput counters.
+/// </summary>
+/// <param name="SpansReceived">Total number of spans received by the OTLP ingestion endpoints.</param>
+/// <param name="SpansStored">Total number of spans persisted to the backing store.</param>
+/// <param name="LogsReceived">Total number of log records received.</param>
+/// <param name="LogsStored">Total number of log records stored.</param>
+/// <param name="MetricsReceived">Total number of metrics payloads received.</param>
+/// <param name="MetricsStored">Total number of metrics payloads stored.</param>
+public readonly record struct ReceiverMetricsSnapshot(
+    long SpansReceived,
+    long SpansStored,
+    long LogsReceived,
+    long LogsStored,
+    long MetricsReceived,
+    long MetricsStored);
+
+/// <summary>
+/// Default implementation backed by <see cref="Meter"/> counters and a broadcaster for live updates.
+/// </summary>
+public class ReceiverMetricsCollector : IReceiverMetricsCollector, IDisposable
+{
+    private readonly Meter _meter;
+    private readonly Counter<long> _spansReceivedCounter;
+    private readonly Counter<long> _spansStoredCounter;
+    private readonly Counter<long> _logsReceivedCounter;
+    private readonly Counter<long> _logsStoredCounter;
+    private readonly Counter<long> _metricsReceivedCounter;
+    private readonly Counter<long> _metricsStoredCounter;
+
+    private long _spansReceived;
+    private long _spansStored;
+    private long _logsReceived;
+    private long _logsStored;
+    private long _metricsReceived;
+    private long _metricsStored;
+
+    private readonly ConcurrentDictionary<Guid, Channel<ReceiverMetricsSnapshot>> _subscribers = new();
+
+    public ReceiverMetricsCollector()
+    {
+        _meter = new Meter("Asynkron.OtelReceiver", "1.0.0");
+        _spansReceivedCounter = _meter.CreateCounter<long>("receiver.spans.received");
+        _spansStoredCounter = _meter.CreateCounter<long>("receiver.spans.stored");
+        _logsReceivedCounter = _meter.CreateCounter<long>("receiver.logs.received");
+        _logsStoredCounter = _meter.CreateCounter<long>("receiver.logs.stored");
+        _metricsReceivedCounter = _meter.CreateCounter<long>("receiver.metrics.received");
+        _metricsStoredCounter = _meter.CreateCounter<long>("receiver.metrics.stored");
+    }
+
+    public void Dispose() => _meter.Dispose();
+
+    public void RecordSpansReceived(long count) => Record(ref _spansReceived, count, _spansReceivedCounter);
+    public void RecordSpansStored(long count) => Record(ref _spansStored, count, _spansStoredCounter);
+    public void RecordLogsReceived(long count) => Record(ref _logsReceived, count, _logsReceivedCounter);
+    public void RecordLogsStored(long count) => Record(ref _logsStored, count, _logsStoredCounter);
+    public void RecordMetricsReceived(long count) => Record(ref _metricsReceived, count, _metricsReceivedCounter);
+    public void RecordMetricsStored(long count) => Record(ref _metricsStored, count, _metricsStoredCounter);
+
+    public async IAsyncEnumerable<ReceiverMetricsSnapshot> WatchAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var channel = Channel.CreateUnbounded<ReceiverMetricsSnapshot>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            AllowSynchronousContinuations = true
+        });
+
+        var id = Guid.NewGuid();
+        _subscribers[id] = channel;
+
+        // Emit the current snapshot immediately so that new subscribers get an initial view.
+        channel.Writer.TryWrite(CreateSnapshot());
+
+        try
+        {
+            while (await channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (channel.Reader.TryRead(out var snapshot))
+                {
+                    yield return snapshot;
+                }
+            }
+        }
+        finally
+        {
+            _subscribers.TryRemove(id, out _);
+        }
+    }
+
+    private void Record(ref long field, long count, Counter<long> counter)
+    {
+        if (count <= 0)
+        {
+            return;
+        }
+
+        counter.Add(count);
+        Interlocked.Add(ref field, count);
+        Broadcast();
+    }
+
+    private void Broadcast()
+    {
+        var snapshot = CreateSnapshot();
+        foreach (var subscriber in _subscribers.Values)
+        {
+            subscriber.Writer.TryWrite(snapshot);
+        }
+    }
+
+    private ReceiverMetricsSnapshot CreateSnapshot() => new(
+        Interlocked.Read(ref _spansReceived),
+        Interlocked.Read(ref _spansStored),
+        Interlocked.Read(ref _logsReceived),
+        Interlocked.Read(ref _logsStored),
+        Interlocked.Read(ref _metricsReceived),
+        Interlocked.Read(ref _metricsStored));
+}

--- a/src/Asynkron.OtelReceiver/Program.cs
+++ b/src/Asynkron.OtelReceiver/Program.cs
@@ -1,6 +1,7 @@
 using Asynkron.OtelReceiver.Data;
-using Asynkron.OtelReceiver.Services;
 using Asynkron.OtelReceiver.Data.Providers;
+using Asynkron.OtelReceiver.Monitoring;
+using Asynkron.OtelReceiver.Services;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -27,6 +28,8 @@ else
     builder.Services.AddScoped<ISpanBulkInserter, PostgresSpanBulkInserter>();
 }
 
+builder.Services.AddSingleton<IReceiverMetricsCollector, ReceiverMetricsCollector>();
+
 builder.Services.AddGrpc();
 
 builder.Services.AddScoped<ModelRepo>();
@@ -36,6 +39,7 @@ var app = builder.Build();
 app.MapGrpcService<TraceServiceImpl>();
 app.MapGrpcService<LogsServiceImpl>();
 app.MapGrpcService<MetricsServiceImpl>();
+app.MapGrpcService<ReceiverMetricsServiceImpl>();
 
 app.MapGet("/", () => "Asynkron Otel Receiver");
 

--- a/src/Asynkron.OtelReceiver/Services/MetricsServiceImpl.cs
+++ b/src/Asynkron.OtelReceiver/Services/MetricsServiceImpl.cs
@@ -4,16 +4,19 @@ using OpenTelemetry.Proto.Collector.Metrics.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using TraceLens.Infra;
 using Asynkron.OtelReceiver.Data;
+using Asynkron.OtelReceiver.Monitoring;
 
 namespace Asynkron.OtelReceiver.Services;
 
 public class MetricsServiceImpl : MetricsService.MetricsServiceBase
 {
     private readonly ModelRepo _repo;
+    private readonly IReceiverMetricsCollector _metrics;
 
-    public MetricsServiceImpl(ModelRepo repo)
+    public MetricsServiceImpl(ModelRepo repo, IReceiverMetricsCollector metrics)
     {
         _repo = repo;
+        _metrics = metrics;
     }
     public override async Task<ExportMetricsServiceResponse> Export(ExportMetricsServiceRequest request, ServerCallContext context)
     {
@@ -76,6 +79,10 @@ public class MetricsServiceImpl : MetricsService.MetricsServiceBase
 
             foreach (var chunk in metrics.Chunk(2000))
                 await _repo.SaveMetrics(chunk);
+        }
+        if (metrics.Count > 0)
+        {
+            _metrics.RecordMetricsReceived(metrics.Count);
         }
         return new ExportMetricsServiceResponse();
     }

--- a/src/Asynkron.OtelReceiver/Services/ReceiverMetricsServiceImpl.cs
+++ b/src/Asynkron.OtelReceiver/Services/ReceiverMetricsServiceImpl.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using Asynkron.OtelReceiver.Monitoring;
+using Asynkron.OtelReceiver.Monitoring.V1;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+
+namespace Asynkron.OtelReceiver.Services;
+
+/// <summary>
+/// Streams live receiver metrics over gRPC so external clients (such as the CLI host) can visualise the data.
+/// </summary>
+public class ReceiverMetricsServiceImpl(IReceiverMetricsCollector metrics) : ReceiverMetricsService.ReceiverMetricsServiceBase
+{
+    public override async Task SubscribeMetrics(
+        Empty request,
+        IServerStreamWriter<ReceiverMetricsUpdate> responseStream,
+        ServerCallContext context)
+    {
+        await foreach (var snapshot in metrics.WatchAsync(context.CancellationToken))
+        {
+            var update = new ReceiverMetricsUpdate
+            {
+                SpansReceived = snapshot.SpansReceived,
+                SpansStored = snapshot.SpansStored,
+                LogsReceived = snapshot.LogsReceived,
+                LogsStored = snapshot.LogsStored,
+                MetricsReceived = snapshot.MetricsReceived,
+                MetricsStored = snapshot.MetricsStored
+            };
+
+            await responseStream.WriteAsync(update).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Asynkron.OtelReceiver.Tests/Asynkron.OtelReceiver.Tests.csproj
+++ b/tests/Asynkron.OtelReceiver.Tests/Asynkron.OtelReceiver.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Asynkron.OtelReceiver\Asynkron.OtelReceiver.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Asynkron.OtelReceiver.Tests/SqliteSpanBulkInserterTests.cs
+++ b/tests/Asynkron.OtelReceiver.Tests/SqliteSpanBulkInserterTests.cs
@@ -1,0 +1,189 @@
+using System.Collections.Generic;
+using System.Threading;
+using Asynkron.OtelReceiver.Data;
+using Asynkron.OtelReceiver.Data.Providers;
+using Asynkron.OtelReceiver.Monitoring;
+using Google.Protobuf;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using Tracelens.Proto.V1;
+using Xunit;
+
+namespace Asynkron.OtelReceiver.Tests;
+
+public class SqliteSpanBulkInserterTests
+{
+    [Fact]
+    public async Task InsertAsync_PersistsAllSpans()
+    {
+        await using var database = await SqliteTestDatabase.CreateAsync();
+        await using var context = database.CreateContext();
+        var inserter = new SqliteSpanBulkInserter();
+
+        var spans = new List<SpanEntity>
+        {
+            CreateSpanEntity(),
+            CreateSpanEntity()
+        };
+
+        await inserter.InsertAsync(context, spans);
+        await context.SaveChangesAsync();
+
+        await using var verification = database.CreateContext();
+        var stored = await verification.Spans.CountAsync();
+        Assert.Equal(spans.Count, stored);
+    }
+
+    [Fact]
+    public async Task SaveTrace_StoresSpansAttributesAndNames()
+    {
+        await using var database = await SqliteTestDatabase.CreateAsync();
+        using var metrics = new ReceiverMetricsCollector();
+        var repo = CreateRepository(database, metrics);
+
+        var span = new Span
+        {
+            TraceId = ByteString.CopyFrom(Guid.NewGuid().ToByteArray()),
+            SpanId = ByteString.CopyFrom(Guid.NewGuid().ToByteArray().AsSpan(0, 8).ToArray()),
+            ParentSpanId = ByteString.CopyFrom(Guid.NewGuid().ToByteArray().AsSpan(0, 8).ToArray()),
+            Name = "TestOperation",
+            StartTimeUnixNano = 1,
+            EndTimeUnixNano = 2,
+        };
+        span.Attributes.Add(new KeyValue
+        {
+            Key = "env",
+            Value = new AnyValue { StringValue = "local" }
+        });
+
+        await repo.SaveTrace(new[]
+        {
+            new SpanWithService
+            {
+                ServiceName = "orders",
+                Span = span
+            }
+        });
+
+        await using var verification = database.CreateContext();
+        Assert.Equal(1, await verification.Spans.CountAsync());
+        Assert.Equal(1, await verification.SpanAttributes.CountAsync());
+        Assert.Equal(1, await verification.SpanNames.CountAsync());
+    }
+
+    [Fact]
+    public async Task SaveLogsAndMetrics_PersistEntities()
+    {
+        await using var database = await SqliteTestDatabase.CreateAsync();
+        using var metrics = new ReceiverMetricsCollector();
+        var repo = CreateRepository(database, metrics);
+
+        var logRecord = new LogRecord
+        {
+            TimeUnixNano = 1,
+            ObservedTimeUnixNano = 1,
+            SpanId = ByteString.CopyFrom(Guid.NewGuid().ToByteArray().AsSpan(0, 8).ToArray()),
+            TraceId = ByteString.CopyFrom(Guid.NewGuid().ToByteArray()),
+            Body = new AnyValue { StringValue = "Test" }
+        };
+
+        var resourceLogs = new ResourceLogs
+        {
+            Resource = new OpenTelemetry.Proto.Resource.V1.Resource()
+        };
+
+        await repo.SaveLogs(new[] { (logRecord, resourceLogs) });
+
+        var metric = new Metric
+        {
+            Name = "requests",
+            Description = "Number of requests",
+            Unit = "1",
+            Gauge = new Gauge()
+        };
+
+        await repo.SaveMetrics(new[]
+        {
+            new MetricEntity
+            {
+                Name = metric.Name,
+                Description = metric.Description,
+                Unit = metric.Unit,
+                Proto = metric.ToByteArray(),
+                AttributeMap = Array.Empty<string>()
+            }
+        });
+
+        await using var verification = database.CreateContext();
+        Assert.Equal(1, await verification.Logs.CountAsync());
+        Assert.Equal(1, await verification.Metrics.CountAsync());
+    }
+
+    private static ModelRepo CreateRepository(SqliteTestDatabase database, ReceiverMetricsCollector metrics)
+    {
+        var contextFactory = database.CreateFactory();
+        return new ModelRepo(contextFactory, NullLogger<ModelRepo>.Instance, new SqliteSpanBulkInserter(), metrics);
+    }
+
+    private static SpanEntity CreateSpanEntity() => new()
+    {
+        SpanId = Guid.NewGuid().ToString("N")[..16],
+        TraceId = Guid.NewGuid().ToString("N"),
+        ParentSpanId = Guid.NewGuid().ToString("N")[..16],
+        OperationName = "op",
+        ServiceName = "svc",
+        StartTimestamp = 1,
+        EndTimestamp = 2,
+        AttributeMap = Array.Empty<string>(),
+        Events = Array.Empty<string>(),
+        Proto = Array.Empty<byte>()
+    };
+
+    private sealed class SqliteTestDatabase : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly DbContextOptions<OtelReceiverContext> _options;
+
+        private SqliteTestDatabase(SqliteConnection connection, DbContextOptions<OtelReceiverContext> options)
+        {
+            _connection = connection;
+            _options = options;
+        }
+
+        public static async Task<SqliteTestDatabase> CreateAsync()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<OtelReceiverContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            await using (var context = new OtelReceiverContext(options))
+            {
+                await context.Database.EnsureCreatedAsync();
+            }
+
+            return new SqliteTestDatabase(connection, options);
+        }
+
+        public OtelReceiverContext CreateContext() => new(_options);
+
+        public IDbContextFactory<OtelReceiverContext> CreateFactory() => new TestContextFactory(_options);
+
+        public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+    }
+
+    private sealed class TestContextFactory(DbContextOptions<OtelReceiverContext> options) : IDbContextFactory<OtelReceiverContext>
+    {
+        public Task<OtelReceiverContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(CreateDbContext());
+
+        public OtelReceiverContext CreateDbContext() => new(options);
+    }
+}


### PR DESCRIPTION
## Summary
- instrument the OTLP receiver with a shared metrics collector and streaming gRPC endpoint
- add a Spectre.Console-based host application that visualises live receiver metrics via the new stream
- cover the SQLite data provider and repository paths with xUnit tests and wire them into a CI workflow

## Testing
- `dotnet test Asynkron.OtelReceiver.sln` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da37b6a37883289c25d84bbf19d4fd