### PR TITLE
Add integration tests for OTLP gRPC ingestion

### DIFF
--- a/src/Asynkron.OtelReceiver/Program.Partial.cs
+++ b/src/Asynkron.OtelReceiver/Program.Partial.cs
@@ -1,0 +1,7 @@
+namespace Asynkron.OtelReceiver;
+
+// Partial definition enables WebApplicationFactory-based integration tests
+// to reference the generated Program class from top-level statements.
+public partial class Program
+{
+}

--- a/tests/Asynkron.OtelReceiver.Tests/Asynkron.OtelReceiver.Tests.csproj
+++ b/tests/Asynkron.OtelReceiver.Tests/Asynkron.OtelReceiver.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">

--- a/tests/Asynkron.OtelReceiver.Tests/OtelGrpcIngestionTests.cs
+++ b/tests/Asynkron.OtelReceiver.Tests/OtelGrpcIngestionTests.cs
@@ -1,0 +1,374 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Asynkron.OtelReceiver;
+using Asynkron.OtelReceiver.Data;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Proto.Collector.Logs.V1;
+using OpenTelemetry.Proto.Collector.Metrics.V1;
+using OpenTelemetry.Proto.Collector.Trace.V1;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Resource.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using Xunit;
+
+namespace Asynkron.OtelReceiver.Tests;
+
+public class OtelReceiverApplicationFactory : WebApplicationFactory<Program>
+{
+    private readonly string _databasePath = Path.Combine(Path.GetTempPath(), $"otel-tests-{Guid.NewGuid():N}.db");
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Force the application under test to use the lightweight SQLite provider.
+        builder.UseSetting("DatabaseProvider", "Sqlite");
+        builder.UseSetting("ConnectionStrings:DefaultConnection", $"Data Source={_databasePath}");
+    }
+
+    public GrpcChannel CreateGrpcChannel()
+    {
+        var httpClient = CreateDefaultClient();
+        httpClient.DefaultRequestVersion = HttpVersion.Version20;
+        httpClient.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+
+        return GrpcChannel.ForAddress(httpClient.BaseAddress ?? new Uri("http://localhost"), new GrpcChannelOptions
+        {
+            HttpClient = httpClient
+        });
+    }
+
+    public async Task<T> ExecuteDbContextAsync<T>(Func<OtelReceiverContext, Task<T>> action)
+    {
+        await using var scope = Services.CreateAsyncScope();
+        var contextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<OtelReceiverContext>>();
+        await using var context = await contextFactory.CreateDbContextAsync();
+        return await action(context);
+    }
+
+    public Task ExecuteDbContextAsync(Func<OtelReceiverContext, Task> action)
+        => ExecuteDbContextAsync(async context =>
+        {
+            await action(context);
+            return true;
+        });
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            try
+            {
+                if (File.Exists(_databasePath))
+                {
+                    File.Delete(_databasePath);
+                }
+            }
+            catch
+            {
+                // The temporary file is best-effort cleanup; swallow IO errors so tests still complete.
+            }
+        }
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        var host = base.CreateHost(builder);
+
+        using var scope = host.Services.CreateScope();
+        var contextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<OtelReceiverContext>>();
+        using var context = contextFactory.CreateDbContext();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+
+        return host;
+    }
+}
+
+public class OtelGrpcIngestionTests : IClassFixture<OtelReceiverApplicationFactory>
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+    private readonly OtelReceiverApplicationFactory _factory;
+
+    static OtelGrpcIngestionTests()
+    {
+        // Allow plaintext HTTP/2 so the in-process gRPC client can talk to TestServer.
+        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+    }
+
+    public OtelGrpcIngestionTests(OtelReceiverApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ExportTrace_PersistsSpans()
+    {
+        using var channel = _factory.CreateGrpcChannel();
+        var client = new TraceService.TraceServiceClient(channel);
+
+        var traceIdBytes = Enumerable.Range(1, 16).Select(i => (byte)i).ToArray();
+        var spanIdBytes = Enumerable.Range(51, 8).Select(i => (byte)i).ToArray();
+        var spanIdHex = Convert.ToHexString(spanIdBytes);
+
+        var request = new ExportTraceServiceRequest
+        {
+            ResourceSpans =
+            {
+                new ResourceSpans
+                {
+                    Resource = new Resource
+                    {
+                        Attributes =
+                        {
+                            new KeyValue
+                            {
+                                Key = "service.name",
+                                Value = new AnyValue { StringValue = "integration-service" }
+                            }
+                        }
+                    },
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Spans =
+                            {
+                                new Span
+                                {
+                                    TraceId = ByteString.CopyFrom(traceIdBytes),
+                                    SpanId = ByteString.CopyFrom(spanIdBytes),
+                                    Name = "integration-span",
+                                    StartTimeUnixNano = 100,
+                                    EndTimeUnixNano = 200,
+                                    Attributes =
+                                    {
+                                        new KeyValue
+                                        {
+                                            Key = "http.method",
+                                            Value = new AnyValue { StringValue = "GET" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await client.ExportAsync(request);
+
+        await WaitForAsync(async () => await _factory.ExecuteDbContextAsync(context =>
+                context.Spans.AnyAsync(span => span.SpanId == spanIdHex)),
+            "span to be persisted");
+
+        var storedSpan = await _factory.ExecuteDbContextAsync(context =>
+            context.Spans.SingleAsync(span => span.SpanId == spanIdHex));
+        Assert.Equal(Convert.ToHexString(traceIdBytes), storedSpan.TraceId);
+        Assert.Equal("integration-service", storedSpan.ServiceName);
+        Assert.Equal("integration-span", storedSpan.OperationName);
+    }
+
+    [Fact]
+    public async Task ExportLogs_PersistsLogRecords()
+    {
+        using var channel = _factory.CreateGrpcChannel();
+        var client = new LogsService.LogsServiceClient(channel);
+
+        var traceIdBytes = Enumerable.Range(11, 16).Select(i => (byte)i).ToArray();
+        var spanIdBytes = Enumerable.Range(3, 8).Select(i => (byte)i).ToArray();
+
+        var request = new ExportLogsServiceRequest
+        {
+            ResourceLogs =
+            {
+                new ResourceLogs
+                {
+                    Resource = new Resource
+                    {
+                        Attributes =
+                        {
+                            new KeyValue
+                            {
+                                Key = "service.name",
+                                Value = new AnyValue { StringValue = "logging-service" }
+                            }
+                        }
+                    },
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            LogRecords =
+                            {
+                                new LogRecord
+                                {
+                                    TimeUnixNano = 300,
+                                    ObservedTimeUnixNano = 300,
+                                    TraceId = ByteString.CopyFrom(traceIdBytes),
+                                    SpanId = ByteString.CopyFrom(spanIdBytes),
+                                    Body = new AnyValue { StringValue = "integration log" },
+                                    SeverityText = "INFO",
+                                    SeverityNumber = (SeverityNumber)9,
+                                    Attributes =
+                                    {
+                                        new KeyValue
+                                        {
+                                            Key = "env",
+                                            Value = new AnyValue { StringValue = "test" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await client.ExportAsync(request);
+
+        await WaitForAsync(async () => await _factory.ExecuteDbContextAsync(context =>
+                context.Logs.AnyAsync(log => log.RawBody == "integration log")),
+            "log record to be persisted");
+
+        var storedLog = await _factory.ExecuteDbContextAsync(context =>
+            context.Logs.SingleAsync(log => log.RawBody == "integration log"));
+        Assert.Equal(Convert.ToHexString(traceIdBytes), storedLog.TraceId);
+        Assert.Equal("integration log", storedLog.RawBody);
+        Assert.Contains("env:test", storedLog.AttributeMap);
+    }
+
+    [Fact]
+    public async Task ExportMetrics_PersistsMetricEntities()
+    {
+        using var channel = _factory.CreateGrpcChannel();
+        var client = new MetricsService.MetricsServiceClient(channel);
+
+        var request = new ExportMetricsServiceRequest
+        {
+            ResourceMetrics =
+            {
+                new ResourceMetrics
+                {
+                    Resource = new Resource
+                    {
+                        Attributes =
+                        {
+                            new KeyValue
+                            {
+                                Key = "service.name",
+                                Value = new AnyValue { StringValue = "metrics-service" }
+                            }
+                        }
+                    },
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = new InstrumentationScope
+                            {
+                                Name = "integration-tests",
+                                Version = "1.0.0",
+                                Attributes =
+                                {
+                                    new KeyValue
+                                    {
+                                        Key = "scope.label",
+                                        Value = new AnyValue { StringValue = "grpc" }
+                                    }
+                                }
+                            },
+                            Metrics =
+                            {
+                                new Metric
+                                {
+                                    Name = "integration_metric",
+                                    Description = "integration test metric",
+                                    Unit = "1",
+                                    Gauge = new Gauge
+                                    {
+                                        DataPoints =
+                                        {
+                                            new NumberDataPoint
+                                            {
+                                                TimeUnixNano = 500,
+                                                AsDouble = 42.0,
+                                                Attributes =
+                                                {
+                                                    new KeyValue
+                                                    {
+                                                        Key = "stage",
+                                                        Value = new AnyValue { StringValue = "test" }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        try
+        {
+            await client.ExportAsync(request);
+        }
+        catch (RpcException ex)
+        {
+            throw new Xunit.Sdk.XunitException($"Metric export failed: {ex.Status.Detail}\n{ex.Status.DebugException}");
+        }
+
+        await WaitForAsync(async () => await _factory.ExecuteDbContextAsync(context =>
+                context.Metrics.AnyAsync(metric => metric.Name == "integration_metric")),
+            "metric to be persisted");
+
+        var storedMetric = await _factory.ExecuteDbContextAsync(context =>
+            context.Metrics.SingleAsync(metric => metric.Name == "integration_metric"));
+        Assert.Equal("integration_metric", storedMetric.Name);
+        Assert.Contains("scope.label:grpc", storedMetric.AttributeMap);
+        Assert.Contains("service.name:metrics-service", storedMetric.AttributeMap);
+    }
+
+    private static async Task WaitForAsync(Func<Task<bool>> predicate, string failureMessage)
+    {
+        var timeoutAt = DateTime.UtcNow + DefaultTimeout;
+        Exception? lastException = null;
+
+        while (DateTime.UtcNow < timeoutAt)
+        {
+            try
+            {
+                if (await predicate())
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Timed out waiting for {failureMessage}. Last exception: {lastException?.Message}");
+    }
+}

--- a/tests/Asynkron.OtelReceiver.Tests/context.md
+++ b/tests/Asynkron.OtelReceiver.Tests/context.md
@@ -1,12 +1,13 @@
 # `Asynkron.OtelReceiver.Tests` Context
 
-xUnit project covering repository and SQLite bulk insert behaviour.
+xUnit project covering repository persistence logic, SQLite bulk insert behaviour, and in-process gRPC ingestion tests.
 
 - [`SqliteSpanBulkInserterTests.cs`](SqliteSpanBulkInserterTests.cs) exercises:
   - `SqliteSpanBulkInserter.InsertAsync` to ensure batches are persisted correctly when `SaveChangesAsync` is invoked.
   - `ModelRepo.SaveTrace` attribute/span-name persistence using an in-memory SQLite database and `ReceiverMetricsCollector`.
   - `ModelRepo.SaveLogs`/`SaveMetrics` to verify log and metric entities are stored.
+- [`OtelGrpcIngestionTests.cs`](OtelGrpcIngestionTests.cs) spins up the full ASP.NET Core host with `WebApplicationFactory`, pushes fake OTLP spans/logs/metrics through the gRPC endpoints, and asserts the database captures the payloads.
 
-Test infrastructure: `SqliteTestDatabase` creates a shared in-memory SQLite connection, builds `OtelReceiverContext`, and exposes an `IDbContextFactory` for repository construction.
+Test infrastructure: `SqliteTestDatabase` creates a shared in-memory SQLite connection for data-layer unit tests, while `OtelReceiverApplicationFactory` provisions a temporary SQLite file and HTTP/2 gRPC channel for end-to-end ingestion scenarios.
 
-Add new tests here when changing data access patterns or metrics recording logic, and update this context with any new fixtures/utilities.
+Add new tests here when changing data access patterns, metrics recording logic, or gRPC ingestion behaviour, and update this context with any new fixtures/utilities.


### PR DESCRIPTION
## Summary
- add a partial Program declaration so WebApplicationFactory can boot the receiver in tests
- add OtelGrpcIngestionTests that send fake OTLP spans, logs, and metrics through the in-process gRPC server
- document the new integration coverage and add the ASP.NET Core testing package to the test project

## Testing
- dotnet build
- dotnet test


------
https://chatgpt.com/codex/tasks/task_e_68da5cb2839c8328b83cdcfeb7fcd4ad