### PR TITLE
Add simple Aspire load generator mode

### DIFF
--- a/samples/AspireShop/AspireShop.AppHost/AppHost.cs
+++ b/samples/AspireShop/AspireShop.AppHost/AppHost.cs
@@ -1,9 +1,21 @@
 using AspireShop.AppHost;
+using Microsoft.Extensions.Configuration;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Host the OtelMCP receiver alongside the Aspire sample so telemetry flows locally by default.
 var otelCollector = builder.AddOtelMcp();
+
+var simpleMode = builder.Configuration.GetValue("OtelMcp:SimpleMode", false);
+
+if (simpleMode)
+{
+    builder.AddProject<Projects.AspireShop_LoadGenerator>("loadgenerator")
+        .WaitFor(otelCollector);
+
+    builder.Build().Run();
+    return;
+}
 
 var postgres = builder.AddPostgres("postgres")
     .WithPgAdmin()

--- a/samples/AspireShop/AspireShop.AppHost/AspireShop.AppHost.csproj
+++ b/samples/AspireShop/AspireShop.AppHost/AspireShop.AppHost.csproj
@@ -14,11 +14,12 @@
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.1" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.4.0" />
     <PackageReference Include="Aspire.Hosting.Redis" Version="9.4.0" />
-    <ProjectReference Include="..\..\src\Asynkron.OtelReceiver\Asynkron.OtelReceiver.csproj" />
+    <ProjectReference Include="..\..\..\src\Asynkron.OtelReceiver\Asynkron.OtelReceiver.csproj" />
     <ProjectReference Include="..\AspireShop.BasketService\AspireShop.BasketService.csproj" />
     <ProjectReference Include="..\AspireShop.CatalogDbManager\AspireShop.CatalogDbManager.csproj" />
     <ProjectReference Include="..\AspireShop.CatalogService\AspireShop.CatalogService.csproj" />
     <ProjectReference Include="..\AspireShop.Frontend\AspireShop.Frontend.csproj" />
+    <ProjectReference Include="..\AspireShop.LoadGenerator\AspireShop.LoadGenerator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/AspireShop/AspireShop.AppHost/OtelMcpExtensions.cs
+++ b/samples/AspireShop/AspireShop.AppHost/OtelMcpExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AspireShop.AppHost;
@@ -28,7 +29,6 @@ internal static class OtelMcpExtensions
             {
                 endpoint.Port = 4317;
                 endpoint.UriScheme = "http";
-                endpoint.Protocol = EndpointProtocol.Http2;
             })
             // Force Kestrel to listen on the canonical OTLP gRPC port so Aspire services
             // can discover it via the generated endpoint reference above.

--- a/samples/AspireShop/AspireShop.LoadGenerator/AspireShop.LoadGenerator.csproj
+++ b/samples/AspireShop/AspireShop.LoadGenerator/AspireShop.LoadGenerator.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+  </ItemGroup>
+</Project>

--- a/samples/AspireShop/AspireShop.LoadGenerator/Program.cs
+++ b/samples/AspireShop/AspireShop.LoadGenerator/Program.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource =>
+        resource.AddService(serviceName: "AspireShop.LoadGenerator", serviceVersion: "1.0.0"))
+    .WithTracing(tracing => tracing
+        .AddSource(TelemetryWorker.ActivitySourceName)
+        .SetSampler(new AlwaysOnSampler())
+        .AddOtlpExporter())
+    .WithMetrics(metrics => metrics
+        .AddMeter(TelemetryWorker.MeterName)
+        .AddRuntimeInstrumentation()
+        .AddOtlpExporter());
+
+builder.Logging.AddOpenTelemetry(logging =>
+{
+    logging.IncludeFormattedMessage = true;
+    logging.IncludeScopes = true;
+    logging.ParseStateValues = true;
+    logging.AddOtlpExporter();
+});
+
+builder.Services.AddHostedService<TelemetryWorker>();
+
+var app = builder.Build();
+await app.RunAsync();
+
+internal sealed class TelemetryWorker(ILogger<TelemetryWorker> logger) : BackgroundService
+{
+    internal const string ActivitySourceName = "AspireShop.LoadGenerator";
+    internal const string MeterName = "AspireShop.LoadGenerator";
+
+    private static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+    private static readonly Meter Meter = new(MeterName);
+    private static readonly Counter<long> PurchaseCounter = Meter.CreateCounter<long>("aspire_shop_purchases");
+    private static readonly Histogram<double> CheckoutDuration = Meter.CreateHistogram<double>(
+        "aspire_shop_checkout_duration", unit: "s");
+
+    private readonly ILogger<TelemetryWorker> _logger = logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var random = new Random();
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var userId = $"user-{random.Next(1000, 9999)}";
+            var itemCount = random.Next(1, 6);
+            var checkoutDelay = TimeSpan.FromMilliseconds(random.Next(250, 1250));
+
+            using var checkout = ActivitySource.StartActivity("basket.checkout", ActivityKind.Server);
+            checkout?.SetTag("app.user.id", userId);
+            checkout?.SetTag("app.basket.item_count", itemCount);
+
+            try
+            {
+                await Task.Delay(checkoutDelay, stoppingToken);
+
+                using (ActivitySource.StartActivity("catalog.lookup", ActivityKind.Client))
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(random.Next(100, 400)), stoppingToken);
+                }
+
+                using (ActivitySource.StartActivity("basket.persist", ActivityKind.Internal))
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(random.Next(50, 150)), stoppingToken);
+                }
+
+                PurchaseCounter.Add(itemCount, new KeyValuePair<string, object?>("app.user.id", userId));
+                CheckoutDuration.Record(checkoutDelay.TotalSeconds, new KeyValuePair<string, object?>("app.user.id", userId));
+
+                checkout?.SetStatus(ActivityStatusCode.Ok);
+                _logger.LogInformation("Simulated checkout for {UserId} containing {ItemCount} items in {Duration} ms.",
+                    userId, itemCount, checkoutDelay.TotalMilliseconds);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                checkout?.SetStatus(ActivityStatusCode.Unset);
+                break;
+            }
+            catch (Exception ex)
+            {
+                checkout?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                _logger.LogError(ex, "Failed to simulate checkout for {UserId}.", userId);
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+        }
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        ActivitySource.Dispose();
+        Meter.Dispose();
+    }
+}

--- a/samples/AspireShop/AspireShop.sln
+++ b/samples/AspireShop/AspireShop.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireShop.ServiceDefaults"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireShop.AppHost", "AspireShop.AppHost\AspireShop.AppHost.csproj", "{1DE972F7-776C-449F-BB39-56FB4DF0ED16}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireShop.LoadGenerator", "AspireShop.LoadGenerator\AspireShop.LoadGenerator.csproj", "{80F8C522-C7FC-427F-9883-F4C4369B490B}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5DBF07AB-BF34-4784-93E5-9E45C1F70548}"
 	ProjectSection(SolutionItems) = preProject
 		deploy-az-cli.md = deploy-az-cli.md
@@ -47,9 +49,13 @@ Global
 		{F1E88A53-F4A9-48E2-9A7B-AAE6986C63AA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1DE972F7-776C-449F-BB39-56FB4DF0ED16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1DE972F7-776C-449F-BB39-56FB4DF0ED16}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1DE972F7-776C-449F-BB39-56FB4DF0ED16}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1DE972F7-776C-449F-BB39-56FB4DF0ED16}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FADE7030-0AAA-4F3E-B7F3-6DBD2AA85A46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1DE972F7-776C-449F-BB39-56FB4DF0ED16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1DE972F7-776C-449F-BB39-56FB4DF0ED16}.Release|Any CPU.Build.0 = Release|Any CPU
+                {80F8C522-C7FC-427F-9883-F4C4369B490B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {80F8C522-C7FC-427F-9883-F4C4369B490B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {80F8C522-C7FC-427F-9883-F4C4369B490B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {80F8C522-C7FC-427F-9883-F4C4369B490B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FADE7030-0AAA-4F3E-B7F3-6DBD2AA85A46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FADE7030-0AAA-4F3E-B7F3-6DBD2AA85A46}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FADE7030-0AAA-4F3E-B7F3-6DBD2AA85A46}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FADE7030-0AAA-4F3E-B7F3-6DBD2AA85A46}.Release|Any CPU.Build.0 = Release|Any CPU

--- a/samples/AspireShop/context.md
+++ b/samples/AspireShop/context.md
@@ -15,6 +15,12 @@ Key subdirectories:
 - [`AspireShop.Frontend`](AspireShop.Frontend) – Blazor WASM front-end that drives traffic into the backend services.
 - [`AspireShop.ServiceDefaults`](AspireShop.ServiceDefaults) – shared service wiring (logging, OpenTelemetry defaults, etc.).
 - [`AspireShop.CatalogDb`](AspireShop.CatalogDb) – schema and data snapshots used by the catalog components.
+- [`AspireShop.LoadGenerator`](AspireShop.LoadGenerator) – simplified worker that produces synthetic traces, metrics, and logs for
+  environments where the containerised dependencies cannot be launched.
+
+Set the `OtelMcp:SimpleMode` configuration value (environment variable `OtelMcp__SimpleMode=true`) to run only the OtelMCP
+collector alongside the load generator. This bypasses the Postgres and Redis containers so telemetry can still be exercised in
+restricted environments such as CI or the hosted evaluation sandbox.
 
 The upstream repository ships additional documentation in [`README.md`](README.md) and reference imagery in [`images`](images/).
 Keep this copy aligned with upstream licensing when updating the sample.


### PR DESCRIPTION
## Summary
- add an `OtelMcp:SimpleMode` branch in the Aspire AppHost that runs OtelMCP with a bundled load generator for environments without containers
- introduce the AspireShop.LoadGenerator worker that emits synthetic traces, metrics, and logs via OpenTelemetry
- wire the new project into the solution and document how to toggle the lightweight mode

## Testing
- dotnet build Asynkron.OtelReceiver.sln
- dotnet test Asynkron.OtelReceiver.sln
- OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317 OTEL_EXPORTER_OTLP_PROTOCOL=grpc dotnet run --project samples/AspireShop/AspireShop.LoadGenerator

------
https://chatgpt.com/codex/tasks/task_e_68da9675e7a483288464e11bbb0f0b9c