### PR TITLE
Fix metric end timestamp aggregation and cover with ingestion test

### DIFF
--- a/src/Asynkron.OtelReceiver/Services/MetricsServiceImpl.cs
+++ b/src/Asynkron.OtelReceiver/Services/MetricsServiceImpl.cs
@@ -41,23 +41,23 @@ public class MetricsServiceImpl : MetricsService.MetricsServiceBase
                             break;
                         case Metric.DataOneofCase.Gauge:
                             start = m.Gauge.DataPoints.Min(d => d.TimeUnixNano);
-                            end = m.Gauge.DataPoints.Min(d => d.TimeUnixNano);
+                            end = m.Gauge.DataPoints.Max(d => d.TimeUnixNano);
                             break;
                         case Metric.DataOneofCase.Sum:
                             start = m.Sum.DataPoints.Min(d => d.TimeUnixNano);
-                            end = m.Sum.DataPoints.Min(d => d.TimeUnixNano);
+                            end = m.Sum.DataPoints.Max(d => d.TimeUnixNano);
                             break;
                         case Metric.DataOneofCase.Histogram:
                             start = m.Histogram.DataPoints.Min(d => d.TimeUnixNano);
-                            end = m.Histogram.DataPoints.Min(d => d.TimeUnixNano);
+                            end = m.Histogram.DataPoints.Max(d => d.TimeUnixNano);
                             break;
                         case Metric.DataOneofCase.ExponentialHistogram:
                             start = m.ExponentialHistogram.DataPoints.Min(d => d.TimeUnixNano);
-                            end = m.ExponentialHistogram.DataPoints.Min(d => d.TimeUnixNano);
+                            end = m.ExponentialHistogram.DataPoints.Max(d => d.TimeUnixNano);
                             break;
                         case Metric.DataOneofCase.Summary:
                             start = m.Summary.DataPoints.Min(d => d.TimeUnixNano);
-                            end = m.Summary.DataPoints.Min(d => d.TimeUnixNano);
+                            end = m.Summary.DataPoints.Max(d => d.TimeUnixNano);
                             break;
                         default:
                             break;

--- a/tests/Asynkron.OtelReceiver.Tests/OtelGrpcIngestionTests.cs
+++ b/tests/Asynkron.OtelReceiver.Tests/OtelGrpcIngestionTests.cs
@@ -307,8 +307,23 @@ public class OtelGrpcIngestionTests
                                         {
                                             new NumberDataPoint
                                             {
-                                                TimeUnixNano = 500,
+                                                StartTimeUnixNano = 100UL,
+                                                TimeUnixNano = 500UL,
                                                 AsDouble = 42.0,
+                                                Attributes =
+                                                {
+                                                    new KeyValue
+                                                    {
+                                                        Key = "stage",
+                                                        Value = new AnyValue { StringValue = "test" }
+                                                    }
+                                                }
+                                            },
+                                            new NumberDataPoint
+                                            {
+                                                StartTimeUnixNano = 400UL,
+                                                TimeUnixNano = 900UL,
+                                                AsDouble = 43.0,
                                                 Attributes =
                                                 {
                                                     new KeyValue
@@ -346,6 +361,9 @@ public class OtelGrpcIngestionTests
         Assert.Equal("integration_metric", storedMetric.Name);
         Assert.Contains("scope.label:grpc", storedMetric.AttributeMap);
         Assert.Contains("service.name:metrics-service", storedMetric.AttributeMap);
+        // Start and end timestamps should mirror the earliest and latest data point samples.
+        Assert.Equal(500UL, storedMetric.StartTimestamp);
+        Assert.Equal(900UL, storedMetric.EndTimestamp);
     }
 
     private static async Task WaitForAsync(Func<Task<bool>> predicate, string failureMessage)


### PR DESCRIPTION
## Summary
- record metric EndTimestamp values using the latest data point per metric type while keeping the start bound at the earliest sample
- extend the gRPC metrics ingestion test to emit two points and assert the stored timestamps track the sample window

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68daae9d890883289fa9aaa7c5b4d431