### PR TITLE
feat: enrich TraceLens search responses

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -5,5 +5,6 @@ This folder collects user-facing operational guides, integration notes, and rese
 Current entries:
 
 - [`aspire-sample-integration.md`](aspire-sample-integration.md) – step-by-step instructions for running the vendored .NET Aspire Shop sample against the receiver to generate realistic OTLP traffic.
+- [`tracelens-search-response.md`](tracelens-search-response.md) – documents the enriched `SearchTraces` response payload (attribute clause matches and optional span protos) so UI/CLI clients can adopt the new metadata.
 
 Add a new document whenever you complete an investigation whose results will be referenced again. Keep filenames descriptive and link to them from parent `context.md` files when relevant.

--- a/docs/tracelens-search-response.md
+++ b/docs/tracelens-search-response.md
@@ -1,0 +1,25 @@
+# TraceLens Search Response Enrichment
+
+`SearchTraces` now returns additional context that helps downstream tooling explain why a trace matched and, when requested, provides the original OTLP span payloads.
+
+## Request flags
+
+- `include_span_protos` (bool): set to `true` to embed the full `opentelemetry.proto.trace.v1.Span` messages for every span in each matched trace. The data is read directly from the persisted `SpanWithService` blobs, so leave the flag unset when you only need the overview to avoid extra payload size.
+
+## Response fields
+
+Each `SearchTraceResult` now contains two extra collections:
+
+- `attribute_clauses`: a list of `AttributeClauseMatch` entries. Each clause records
+  - `clause`: a human-readable representation of the filter expression that succeeded (e.g., `tag:http.method=GET`).
+  - `satisfied`: `true` if the persisted spans satisfied the clause.
+  - `matches`: the individual `AttributeMatch` items (span id, key, value) that satisfied the clause.
+- `spans`: present when `include_span_protos` was set on the request and populated with the OTLP `Span` protos for each matched span.
+
+Tooling that previously only inspected the `trace` overview and aggregated log/span counts can now surface:
+
+- Which filter clause(s) caused the trace to be returned (for annotating UI chips, CLI output, etc.).
+- The exact span attributes that satisfied each clause (useful for building “why did I see this trace?” explanations).
+- The raw span protos without issuing a follow-up call, enabling quick drill-down panes in dashboards.
+
+Update existing consumers to read the new fields opportunistically so older servers remain compatible: treat missing fields as “feature unavailable” and fall back to previous behaviour.

--- a/src/Asynkron.OtelReceiver/Data/context.md
+++ b/src/Asynkron.OtelReceiver/Data/context.md
@@ -12,6 +12,7 @@ The data layer converts OTLP payloads into persisted records and exposes read/wr
 
 ### Usage notes
 - `ModelRepo.SaveTrace` writes spans via `ISpanBulkInserter`, updates attribute/name lookup tables with conflict-tolerant raw SQL, and records ingestion counters.
+- `ModelRepo.SearchTraces` now annotates matching attribute clauses (span id, key, value) and can optionally hydrate the original OTLP span protos when callers set `include_span_protos` on the request.
 - `SaveLogs` and `SaveMetrics` transform OTLP structures into relational rows while computing derived attributes (`AttributeMap`, formatting log bodies).
 - Snapshot and metadata endpoints support TraceLens visualisation features (see [`../TraceLens/context.md`](../TraceLens/context.md)).
 

--- a/src/Asynkron.OtelReceiver/Services/context.md
+++ b/src/Asynkron.OtelReceiver/Services/context.md
@@ -6,7 +6,7 @@ This directory contains gRPC service implementations wired into the ASP.NET Core
 - [`LogsServiceImpl.cs`](LogsServiceImpl.cs) – mirrors the trace workflow for log records, chunking payloads and invoking `ModelRepo.SaveLogs` while updating metrics counters.
 - [`MetricsServiceImpl.cs`](MetricsServiceImpl.cs) – processes OTLP metrics synchronously: combines resource/scope attributes, normalises timestamps per metric type, persists via `ModelRepo.SaveMetrics` once per request to avoid duplicating rows, and records ingestion totals.
 - [`ReceiverMetricsServiceImpl.cs`](ReceiverMetricsServiceImpl.cs) – exposes a server-streaming endpoint backed by `IReceiverMetricsCollector.WatchAsync`, allowing external tooling (e.g., `ReceiverMetricsConsole`) to observe live counts.
-- [`DataServiceImpl.cs`](DataServiceImpl.cs) – surfaces TraceLens search, metadata, and metrics queries so clients can explore persisted telemetry.
+- [`DataServiceImpl.cs`](DataServiceImpl.cs) – surfaces TraceLens search, metadata, and metrics queries so clients can explore persisted telemetry, including the enriched search responses (attribute clause matches and optional span protos).
 - [`McpStreamingEndpoint.cs`](McpStreamingEndpoint.cs) – provides a newline-delimited JSON streaming HTTP endpoint that mirrors the TraceLens DataService gRPC commands for Model Context Protocol clients.
 
 Supporting infrastructure:

--- a/src/Asynkron.OtelReceiver/tracelens.proto
+++ b/src/Asynkron.OtelReceiver/tracelens.proto
@@ -38,6 +38,7 @@ message SearchTracesRequest {
   uint64 end_time = 6;
   int32 limit = 7;
   string log_search = 8;
+  bool include_span_protos = 9;
 }
 
 message SpanOverview {
@@ -54,9 +55,23 @@ message TraceOverview {
   bool has_error = 7;
 }
 
+message AttributeMatch {
+  string span_id = 1;
+  string key = 2;
+  string value = 3;
+}
+
+message AttributeClauseMatch {
+  string clause = 1;
+  bool satisfied = 2;
+  repeated AttributeMatch matches = 3;
+}
+
 message SearchTraceResult {
   TraceOverview trace = 1;
   repeated opentelemetry.proto.logs.v1.LogRecord logs = 2;
+  repeated AttributeClauseMatch attribute_clauses = 3;
+  repeated opentelemetry.proto.trace.v1.Span spans = 4;
 }
 
 message SearchTracesResponse {

--- a/tests/Asynkron.OtelReceiver.Tests/DataServiceTests.cs
+++ b/tests/Asynkron.OtelReceiver.Tests/DataServiceTests.cs
@@ -44,6 +44,7 @@ public class DataServiceTests
         var traceIdBytes = Enumerable.Range(10, 16).Select(i => (byte)i).ToArray();
         var spanIdBytes = Enumerable.Range(1, 8).Select(i => (byte)(i + 40)).ToArray();
         var traceIdHex = Convert.ToHexString(traceIdBytes);
+        var spanIdHex = Convert.ToHexString(spanIdBytes);
 
         var traceRequest = new ExportTraceServiceRequest
         {
@@ -166,13 +167,25 @@ public class DataServiceTests
             ServiceName = "search-service",
             TagName = "http.method",
             TagValue = "GET",
-            Limit = 5
+            Limit = 5,
+            IncludeSpanProtos = true
         });
 
         var traceResult = Assert.Single(searchResponse.Results);
         Assert.Equal(traceIdHex, traceResult.Trace.TraceId);
         Assert.NotEmpty(traceResult.Trace.Spans);
         Assert.All(traceResult.Trace.Spans, span => Assert.Equal("search-service", span.ServiceName));
+        var clause = Assert.Single(traceResult.AttributeClauses);
+        Assert.True(clause.Satisfied);
+        Assert.Equal("tag:http.method=GET", clause.Clause);
+        var match = Assert.Single(clause.Matches);
+        Assert.Equal(spanIdHex, match.SpanId);
+        Assert.Equal("http.method", match.Key);
+        Assert.Equal("GET", match.Value);
+        Assert.NotEmpty(traceResult.Spans);
+        Assert.Equal("root-operation", traceResult.Spans[0].Name);
+        Assert.Equal(traceIdBytes, traceResult.Spans[0].TraceId.ToByteArray());
+        Assert.Equal(spanIdBytes, traceResult.Spans[0].SpanId.ToByteArray());
         Assert.NotEmpty(searchResponse.LogCounts);
         Assert.NotEmpty(searchResponse.SpanCounts);
         Assert.Single(traceResult.Logs);


### PR DESCRIPTION
## Summary
- extend SearchTraces to annotate attribute clause matches and optionally return full span protos
- update ModelRepo, services, and tests to surface the new metadata without extra database work
- document the enriched payload so downstream tooling can adopt the new fields

## Testing
- dotnet build Asynkron.OtelReceiver.sln
- dotnet test Asynkron.OtelReceiver.sln


------
https://chatgpt.com/codex/tasks/task_e_68dab1850ca083289aa2f6820198e9d3